### PR TITLE
feat#96 : 영화 기록 선택 이후 폼까지 연동하기

### DIFF
--- a/src/contents/Movie/MovieForm.css
+++ b/src/contents/Movie/MovieForm.css
@@ -50,22 +50,82 @@
   resize: vertical;
 }
 
-/* 별점 */
-.movieform-stars {
-  flex: 1;
-  padding-top: 6px;
-  font-size: 20px;
+/* 별점 완벽 UI */
+.movieform-stars-input {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px;
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  border-radius: 16px;
+  border: 1px solid #dee2e6;
+}
+
+.stars-visual {
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 
 .star {
-  color: #ced4da;
-  cursor: pointer;
-  margin-right: 4px;
+  font-size: 26px;
+  color: #dee2e6;
+  transition: all 0.2s;
+  cursor: default;
 }
 
-.star.active {
-  color: #339af0;
+.star.full { color: #ffd700; }
+.star.half { 
+  color: #ffd700; 
+  position: relative;
+  overflow: hidden;
+  width: 14px;
 }
+.star.half::before {
+  content: '★';
+  position: absolute;
+  left: 0;
+  color: #ffd700;
+  width: 50%;
+}
+
+.rating-text {
+  font-size: 18px;
+  font-weight: 700;
+  color: #495057;
+  margin-left: 12px;
+  min-width: 50px;
+}
+
+.star-input {
+  width: 72px;
+  height: 44px;
+  padding: 0 12px;
+  font-size: 20px;
+  font-weight: 700;
+  border: 2px solid #dee2e6;
+  border-radius: 12px;
+  text-align: center;
+  background: white;
+}
+
+.star-input:focus {
+  border-color: #ffd700;
+  box-shadow: 0 0 0 4px rgba(255, 215, 0, 0.15);
+}
+
+@media (max-width: 768px) {
+  .movieform-stars-input {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+  
+  .stars-visual {
+    justify-content: center;
+  }
+}
+
 
 /* 버튼 */
 .movieform-footer {

--- a/src/contents/Movie/MovieForm.tsx
+++ b/src/contents/Movie/MovieForm.tsx
@@ -1,73 +1,167 @@
 // src/contents/Movie/MovieForm.tsx
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import "./MovieForm.css";
+import axios from "axios";
+
+interface MovieVO {
+  num: number;
+  title: string;
+  director: string;
+  actor: string;
+  genre: string;
+  poster: string;
+  release_date: string;
+}
+
+interface MovieFormVO {
+  num: number;
+  movie_id: number;
+  writer: number;
+  toge_writer: number;
+  simple_review: string;
+  review: string,
+  rate: number;
+  hit: number;
+}
 
 const MovieForm: React.FC = () => {
+  const { num } = useParams<{ num: string }>();
+  const location = useLocation();
+  const state = location.state as { movie: MovieVO } | null;
   const navigate = useNavigate();
+
   // TODO: 실제 로그인 유저 / 친구 목록은 props나 API로 대체
-  const currentUser = { nickname: "사용자1" };
+  const currentUser = { writer: 3, nickname: "사용자" };
   const friends = [
-    { id: 0, nickname: "개인" },
-    { id: 1, nickname: "영화덕후99" },
-    { id: 2, nickname: "애니좋아" },
-    { id: 3, nickname: "스릴러매니아" },
+    { toge_writer: 1, nickname: "성우" },
+    { toge_writer: 4, nickname: "테스형" },
+    { toge_writer: 41, nickname: "성우임" },
   ];
 
-  const [selectedFriendId, setSelectedFriendId] = useState<number | "">("");
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  // 기본 폼 값 입력, 전 페이지에서 넘어오는 영화 id 값 넣어주기
+  const [formData, setFormData] = useState<MovieFormVO>({
+    num: 0,
+    movie_id: state?.movie?.num || parseInt(num || '0'),
+    writer: currentUser.writer, // 추후에 로그인 하면 그 때 마다 바꾸게 설정
+    toge_writer: 1,
+    simple_review: '',
+    review: '',
+    rate: 0,
+    hit: 0
+  });
 
-    const selectedFriend =
-      selectedFriendId === ""
-        ? null
-        : friends.find((f) => f.id === selectedFriendId);
 
-    // 업로드 시 함께 작성자 정보 사용 예시
-    const payload = {
-      writer: currentUser.nickname,
-      coWriter: selectedFriend ? selectedFriend.nickname : null,
-      // 한줄평/감상평/별점 값은 추후 상태로 관리해서 같이 보냄
-    };
+  const [selectedFriendId, setSelectedFriendId] = useState<number>(0); // 0 이면 친구 미선택
+  const [starRating, setStarRating] = useState<number>(0); // 별점 상태 추가
+  const [isSubmitting, setIsSubmitting] = useState(false); // false면 버튼 활성화, true면 비활성화
 
-    console.log("submit payload", payload);
-    // 업로드 처리 로직 추가 예정
+  //movie_id 자동 설정 해주기
+  useEffect(() => {
+    if (state?.movie?.num) {
+      setFormData(prev => ({ ...prev, movie_id: state.movie.num }));
+    }
+  }, [state?.movie?.num]);
 
+  // 별점 변경하기 ( 0~5 소수점 1자리)
+  const handleStarRatingChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // 정규식 이용하기
+    const inputValue = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');
+    const numValue = parseFloat(inputValue) || 0;
+    const clampedValue = Math.max(0, Math.min(5, numValue));
+    setStarRating(clampedValue);
+    setFormData(prev => ({ ...prev, rate: clampedValue }));
   };
+
+  // 한줄평 변경
+  const handleSimpleReviewChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, simple_review: e.target.value }));
+  };
+
+  // 감상평 변경
+  const handleReviewChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setFormData(prev => ({ ...prev, review: e.target.value }));
+  };
+
+  // 친구 선택 변경
+  const handleFriendChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const friendId = e.target.value === "" ? 0 : Number(e.target.value);
+    setSelectedFriendId(friendId);
+    setFormData(prev => ({ ...prev, toge_writer: friendId }));
+  };
+
+  // 별점 시각화
+  const renderStars = () => {
+    const fullStars = Math.floor(starRating);
+    const hasHalfStar = starRating % 1 !== 0;
+    return Array.from({ length: 5 }, (_, i) => {
+      if (i < fullStars) return <span key={i} className="star full">★</span>;
+      if (i === fullStars && hasHalfStar) return <span key={i} className="star half">★</span>;
+      return <span key={i} className="star empty">☆</span>;
+    });
+  };
+
+  // handleSubmit에서 별점 포함
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    
+    try {
+      console.log('전송 데이터 :', formData);
+      const response = await axios.post(`${process.env.REACT_APP_BACK_END_URL}/movie/movieformadd`,
+        formData,
+        {
+          
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+      console.log('업로드 성공', response.data)
+      alert('영화 기록이 등록되었습니다.')
+      navigate('/movielog')
+    } catch (error) {
+      console.log('업로드 실패 :', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+
+
 
   return (
     <div className="movieform-wrapper">
       <h2 className="movieform-step-title">영화 기록 - 게시글 작성 2단계</h2>
 
       <form className="movieform-card" onSubmit={handleSubmit}>
+
+        {/* 선택된 영화 정보 표시 */}
+        {state?.movie && (
+          <div className="movieform-movie-info">
+            <h3>{state.movie.title}</h3>
+            <p>{state.movie.actor} | {state.movie.genre}</p>
+          </div>
+        )}
+
         {/* 작성자 영역 */}
         <div className="movieform-field movieform-writer-row">
           <label className="movieform-label">작성자</label>
           <div className="movieform-writer-area">
-            {/* 기본: 로그인 사용자 */}
             <div className="movieform-writer">
               <div className="movieform-writer-avatar">A</div>
-              <span className="movieform-writer-name">
-                {currentUser.nickname}
-              </span>
+              <span className="movieform-writer-name">{currentUser.nickname}</span>
             </div>
-
-            {/* 친구 선택 드롭다운 */}
             <div className="movieform-coWriter">
               <span className="writer-plus">,</span>
               <select
                 className="writer-select"
                 value={selectedFriendId}
-                onChange={(e) =>
-                  setSelectedFriendId(
-                    e.target.value === "" ? "" : Number(e.target.value)
-                  )
-                }
+                onChange={handleFriendChange}
               >
-                <option value="">추가 작성자</option>
+                {/* 임의 숫자 값을 입력해준다. 추후에 친구 기능과 합치기 */}
+                <option value={1}>추가 작성자</option> 
                 {friends.map((friend) => (
-                  <option key={friend.id} value={friend.id}>
+                  <option key={friend.toge_writer} value={friend.toge_writer}>
                     {friend.nickname}
                   </option>
                 ))}
@@ -77,12 +171,15 @@ const MovieForm: React.FC = () => {
         </div>
 
         {/* 한 줄 평 */}
-        <div className="movieform-field">
+       <div className="movieform-field">
           <label className="movieform-label">한 줄 평</label>
           <input
             type="text"
             className="movieform-input"
             placeholder="한 줄 평을 입력하세요"
+            value={formData.simple_review}
+            onChange={handleSimpleReviewChange}
+            maxLength={100}
           />
         </div>
 
@@ -92,27 +189,42 @@ const MovieForm: React.FC = () => {
           <textarea
             className="movieform-textarea"
             placeholder="감상평을 입력하세요"
+            value={formData.review}
+            onChange={handleReviewChange}
+            rows={5}
+            maxLength={1000}
           />
         </div>
 
         {/* 별점 */}
         <div className="movieform-field">
           <label className="movieform-label">별점</label>
-          <div className="movieform-stars">
-            <span className="star active">★</span>
-            <span className="star">★</span>
-            <span className="star">★</span>
-            <span className="star">★</span>
-            <span className="star">★</span>
+          <div className="movieform-stars-input">
+            <div className="stars-visual">
+              {renderStars()}
+              <span className="rating-text">{starRating.toFixed(1)} / 5.0</span>
+            </div>
+            <input
+              type="number"
+              min="0"
+              max="5"
+              step="0.1"
+              value={starRating}
+              onChange={handleStarRatingChange}
+              className="star-input"
+              placeholder="0.0"
+            />
           </div>
         </div>
 
+
         {/* 업로드 버튼 */}
         <div className="movieform-footer">
-         <button
-            type="button"
+          <button
+            type="submit"
             className="movieform-submit-btn"
-            onClick={() => navigate("/movielog")}>
+            disabled={isSubmitting}
+            >
             업로드
           </button>
 

--- a/src/contents/Movie/MovieSearch.tsx
+++ b/src/contents/Movie/MovieSearch.tsx
@@ -46,11 +46,10 @@ const MovieSearch: React.FC = () => {
   };
 
   const handleNext = () => {
-    if (selectedMovie) {
-      navigate(`/movieform/`, { state: { movie: selectedMovie } });
-    } else {
+    if (!selectedMovie) {
       alert("영화를 선택해주세요!");
-    }
+    } 
+    navigate(`/movieform/${selectedMovie?.num}`,{state: {movie: selectedMovie}})
   };
 
   return (


### PR DESCRIPTION
feat#96 : 영화 기록 선택 이후 폼까지 연동하기

<img width="971" height="855" alt="image" src="https://github.com/user-attachments/assets/1c544e9d-a5d7-4c4f-96df-4ba7c38a5cdd" />
영화 선택 이후

<img width="828" height="688" alt="image" src="https://github.com/user-attachments/assets/5b89d3b9-ac4b-424d-ab06-efd1284fcc9a" />
선택된 영화가 나오고

<img width="861" height="921" alt="image" src="https://github.com/user-attachments/assets/95818478-833a-4c6c-b9c4-8eebe8124453" />
프론트엔드에서 업로드가 완료되며


<img width="1556" height="240" alt="image" src="https://github.com/user-attachments/assets/1d4cea50-ecd3-4455-b08a-3f20670a0f1e" />
DB에도 잘 들어갑니다. 

추후에 로그인 , 친구목록에 있는 사용자 id만 지속적으로 변경 해주면 됩니다.