### PR TITLE
Feat#128:  마이페이지(장르 통계 연동, 본인 게시글만 표시), MovieInfo 구현, 다이어리 오류 수정

### DIFF
--- a/src/contents/Diary/Diary.tsx
+++ b/src/contents/Diary/Diary.tsx
@@ -4,36 +4,39 @@ import { useAuth } from '../../components/AuthProvider'
 import axios from 'axios'
 import './Diary.css'
 
-interface DiaryVO {
-  num: number
-  movieId: number
-  writer: number
-  togeWriter: number
-  simpleReview: string
-  review: string
-  title: string
-  poster: string
-  writerName: string
-  togeWriterName: string
-  rate: number;
+interface MovieLogVO {
+  num: number;
+  title: string;
+  poster: string;
   genre: string;
+
+  writer_num: number;
+  writer_name: string;
+
+  toge_writer_num?: number;
+  toge_writer_name?: string;
+
+  simple_review: string;
+  review: string;
+  rate: number;
+  hit: number;
+  created_at: string;
 }
 
 const Diary: React.FC = () => {
   const { member } = useAuth()
-  const [myData, setMyData] = useState<DiaryVO[]>([])
+  const [movieLogs, setMovieLogs] = useState<MovieLogVO[]>([])
 
-  useEffect(() => {
-    if (!member || member.num == null) return
-
+  React.useEffect(() => {
     axios
-      .get(`${process.env.REACT_APP_BACK_END_URL}/api/diary/my`, {
-        params: { memberNum: member.num },
-        withCredentials: true
+      .get(`${process.env.REACT_APP_BACK_END_URL}/movie/mylist`, { withCredentials: true })
+      .then((res) => {
+        setMovieLogs(res.data.data);
       })
-      .then(res => setMyData(res.data))
-      .catch(err => console.error('Diary 불러오기 실패', err))
-  }, [member])
+      .catch((err) =>
+        console.error("MyPage movie list load error", err)
+      );
+  }, []);
 
   return (
     <div className="diary-wrapper">
@@ -63,34 +66,34 @@ const Diary: React.FC = () => {
           </div>
 
           {/* 페이지 */}
-          {myData.map((entry, index) => (
-            <div className="diary-page" key={index}>
+          {movieLogs.map((log, idx) => (
+            <div className="diary-page" key={idx}>
               {/* 상단: 포스터 + 제목/작성자 */}
               <div className="top-area">
                 <div className="poster-area">
-                  <img src={entry.poster} alt={entry.title} />
+                  <img src={log.poster} alt={log.title} />
                 </div>
 
                 <div className="meta-area">
-                  <h3>{entry.title}</h3>
+                  <h3>{log.title}</h3>
 
                   <div className="genre-tags">
-                    {entry.genre?.split('/').map(g => (
+                    {log.genre?.split('/').map(g => (
                       <span key={g} className="genre-tag">{g}</span>
                     ))}
                   </div>
 
-                  {entry.rate != null && (
+                  {log.rate != null && (
                     <div className="rating">
-                      {'★'.repeat(entry.rate)}
-                      {'☆'.repeat(5 - entry.rate)}
+                      {'★'.repeat(log.rate)}
+                      {'☆'.repeat(5 - log.rate)}
                     </div>
                   )}
                   <span className="writer">
-                    {entry.writerName}
+                    {log.writer_name}
                     <div>
-                    {entry.togeWriterName && (
-                      <span className="together"> 👤➕{entry.togeWriterName}</span>
+                    {log.toge_writer_num && (
+                      <span className="together"> 👤➕{log.toge_writer_name}</span>
                     )}
                     </div>
                   </span>
@@ -99,8 +102,8 @@ const Diary: React.FC = () => {
 
               {/* 하단: 리뷰 */}
               <div className="bottom-area">
-                <p className="simple">{entry.simpleReview || '—'}</p>
-                <div className="review">{entry.review}</div>
+                <p className="simple">{log.title || '—'}</p>
+                <div className="review">{log.review}</div>
               </div>
             </div>
           ))}

--- a/src/contents/Movie/MovieInfo.css
+++ b/src/contents/Movie/MovieInfo.css
@@ -3,20 +3,38 @@
   margin: 40px auto 80px;
   font-family: "Pretendard", -apple-system, system-ui, sans-serif;
   color: #212529;
+  padding: 0 16px;
 }
 
-/* 큰 카드 박스 */
+/* ==== 영화 정보 카드 ==== */
 .movieinfo-card {
   background-color: #ffffff;
   border-radius: 16px;
   padding: 32px 36px;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease-in-out;
+}
+/* 리뷰 카드: 한 줄에 두 개 */
+.movieinfo-review-card {
+  width: calc(50% - 8px);
+  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  background-color: #ffffff;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: box-shadow 0.2s ease-in-out;
+}
+.movieinfo-card:hover {
+  transform: translateY(-4px);
 }
 
 /* 상단: 포스터 + 정보 */
 .movieinfo-top {
   display: flex;
-  gap: 32px;
+  gap: 36px;
+  flex-wrap: wrap;
 }
 
 .movieinfo-poster-box {
@@ -27,6 +45,7 @@
   width: 100%;
   border-radius: 12px;
   object-fit: cover;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
 }
 
 .movieinfo-main {
@@ -36,73 +55,138 @@
 .movieinfo-title-row {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  margin-bottom: 10px;
+  gap: 10px;
+  margin-bottom: 12px;
 }
 
 .movieinfo-title {
-  font-size: 28px;
+  font-size: 30px;
   font-weight: 700;
+  line-height: 1.2;
 }
 
 .movieinfo-year {
   font-size: 23px;
-  color: #525252;
+  color: #868e96;
+  margin-left: 5px;
 }
 
-/* 장르 배지 */
+/* 장르 버튼 */
 .movieinfo-genre-badge {
-  border-radius: 999px;
-  background-color: #e7f1ff;
-  color: #1c7ed6;
-  font-size: 13px;
-  padding: 6px 14px;
-  border: none;
-  margin-bottom: 18px;
+  border: none !important;
+  padding: 5px 12px !important;
+  border-radius: 999px !important;
+  background-color: #dfecff !important;
+  color: #0d6efd !important;
+  font-size: 15px !important;
+  font-weight: bold !important;
 }
 
+/* 메타 정보 (개봉/감독/배우/평점) */
 .movieinfo-meta {
-  font-size: 14px;
-  line-height: 1.7;
+  margin-top: 20px;
+  font-size: 15px; 
+  font-weight: 600;
+  line-height: 1.8;
+  color: #495057;
 }
 
-/* 하단: 별점 + 리뷰 두 열 레이아웃 */
-.movieinfo-bottom {
-  display: grid;
-  grid-template-columns: 1.1fr 1.4fr;
-  gap: 28px;
-  margin-top: 32px;
+.movieinfo-meta div {
+  margin-bottom: 6px;
 }
 
+.movieinfo-meta .movieinfo-rating {
+  font-weight: 600;
+  color: #f59f00;
+}
+
+/* ==== 리뷰 / 한줄평 섹션 ==== */
+/* 제목 */
 .movieinfo-subtitle {
   font-size: 16px;
   font-weight: 600;
-  margin-bottom: 10px;
+  margin-top: 30px;
+  margin-bottom: 16px;
 }
 
-/* 별점 숫자/별 아이콘 라인 */
-.movieinfo-score-line {
+.movieinfo-review-list {
   display: flex;
-  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px; 
+  margin-top: 20px;
+}
+
+/* 리뷰 카드 */
+.movieinfo-review-card {
+  width: calc(50% - 8px);
+  border-radius: 12px;
+  border: 1px solid #e5e5e5;
+  background-color: #ffffff;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  margin-bottom: 14px;
+  transition: box-shadow 0.2s ease-in-out;
 }
 
-.movieinfo-stars {
-  font-size: 20px;
-  color: #4dabf7;
+.movieinfo-review-card:hover {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
 }
 
-.movieinfo-score {
+/* 헤더: 프로필 + 닉네임 + 별점 */
+.review-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* 프로필 */
+.review-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: #f1f3f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 16px;
-  color: #4dabf7;
+  font-weight: 600;
+  color: #495057;
+}
+
+/* 닉네임 */
+.review-name {
+  font-size: 14px;
   font-weight: 600;
 }
 
-/* 별점 분포 막대 */
-/* .movieinfo-bar-list {
+/* 별점: 오른쪽 끝 */
+.review-rate {
+  margin-left: auto;
+  font-weight: 600;
+  color: #f59f00;
+}
+
+/* 작성일: 닉네임 아래, 작은 글씨 */
+.review-date {
+  font-size: 14px;
+  color: #868e96;
+  margin-left: 0; 
   margin-top: 4px;
 }
+
+/* 리뷰 텍스트 */
+.review-text {
+  font-size: 14px;
+  color: #495057;
+  margin: 0;
+}
+
+/* ==== 별점 막대 (옵션) ==== */
+.movieinfo-bar-list {
+  margin-top: 6px;
+}
+
 .movieinfo-bar-row {
   display: flex;
   align-items: center;
@@ -110,11 +194,13 @@
   margin-bottom: 6px;
   font-size: 12px;
 }
+
 .bar-label {
   width: 26px;
   text-align: right;
   color: #868e96;
 }
+
 .bar-track {
   flex: 1;
   height: 6px;
@@ -122,77 +208,15 @@
   background-color: #f1f3f5;
   overflow: hidden;
 }
+
 .bar-fill {
   height: 100%;
   border-radius: 999px;
   background: linear-gradient(90deg, #4dabf7, #1c7ed6);
 }
+
 .bar-percent {
   width: 38px;
   text-align: right;
   color: #868e96;
-} */
-
-/* 한줄평 카드 */
-.movieinfo-review-list {
-  display: flex;
-  margin-top: 20px;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.movieinfo-review-card {
-  border-radius: 12px;
-  border: 1px solid #e5e5e5;
-  background-color: #ffffff;
-  padding: 14px 16px;
-}
-
-.review-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 6px;
-}
-
-.review-avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background-color: #f1f3f5;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-}
-
-.review-name {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.review-tag {
-  font-size: 11px;
-  color: #4dabf7;
-}
-
-.review-text {
-  font-size: 13px;
-  color: #495057;
-  margin: 0;
-}
-
-/* 반응형 */
-@media (max-width: 900px) {
-  .movieinfo-top {
-    flex-direction: column;
-  }
-
-  .movieinfo-bottom {
-    grid-template-columns: 1fr;
-  }
-
-  .movieinfo-wrapper {
-    margin: 20px auto 60px;
-  }
 }

--- a/src/contents/Movie/MovieInfo.tsx
+++ b/src/contents/Movie/MovieInfo.tsx
@@ -1,139 +1,131 @@
-// src/contents/Movie/MovieInfo.tsx (원하는 경로에 생성)
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
 import "./MovieInfo.css";
-import { Link } from "react-router-dom";
+
+interface MovieVO {
+  num: number;
+  title: string;
+  year?: number;
+  genre: string;
+  release_date: string;
+  director: string;
+  actor: string;
+  poster: string;
+  rating?: number;
+}
+
+interface MovieFormVO {
+  num: number;
+  movie_id: number;
+  writer: string;
+  toge_writer: string | null;
+  simple_review: string;
+  review: string;
+  rate: number;
+  hit: number;
+  created_at?: string;
+  updated_at?: string;
+}
 
 const MovieInfo: React.FC = () => {
-  // TODO: 실제로는 useParams 등으로 id 받아서 데이터 조회
-  const movie = {
-    title: "어벤져스 엔드게임",
-    year: 2019,
-    genre: "액션",
-    release: "2025년 11월",
-    director: "어벤져스",
-    actors: "토르, 헐크, 등",
-    poster: "/images/poster4.jpg", // 실제 포스터 경로로 교체
-    rating: 4.5,
-  };
+  const { movieId } = useParams<{ movieId: string }>();
+  const [movie, setMovie] = useState<MovieVO | null>(null);
+  const [reviews, setReviews] = useState<MovieFormVO[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMovie = async () => {
+      if (!movieId) return;
+
+      try {
+        const res = await axios.get(
+          `${process.env.REACT_APP_BACK_END_URL}/movie/movieInfo`,
+          { params: { num: movieId }, withCredentials: true }
+        );
+        setMovie(res.data);
+      } catch (e: any) {
+        console.error("영화 상세 조회 실패", e.response?.status, e.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMovie();
+  }, [movieId]);
+
+  // 영화 기록 가져오기
+  useEffect(() => {
+    if (!movieId) return;
+
+    const fetchReviews = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.REACT_APP_BACK_END_URL}/movie/movieFormsByMovie`,
+          { params: { num: movieId }, withCredentials: true }
+        );
+        console.log("리뷰 응답:", res.data.forms);
+        setReviews(res.data.forms || []);
+      } catch (err) {
+        console.error("리뷰 불러오기 실패", err);
+      }
+    };
+
+    fetchReviews();
+  }, [movieId]);
+
+  if (loading) return <div className="movieinfo-wrapper">로딩중...</div>;
+  if (!movie) return <div className="movieinfo-wrapper">영화를 찾을 수 없습니다.</div>;
 
   return (
     <div className="movieinfo-wrapper">
+      {/* 영화 정보 카드 */}
       <div className="movieinfo-card">
-        {/* 상단: 포스터 + 기본 정보 */}
         <div className="movieinfo-top">
           <div className="movieinfo-poster-box">
-            <img
-              src={movie.poster}
-              alt={movie.title}
-              className="movieinfo-poster"
-            />
+            <img src={movie.poster} alt={movie.title} className="movieinfo-poster" />
           </div>
-
           <div className="movieinfo-main">
             <div className="movieinfo-title-row">
               <h2 className="movieinfo-title">{movie.title}</h2>
-              <span className="movieinfo-year">{movie.year}</span>
+              <span className="movieinfo-year">{movie.release_date?.substring(0, 4)}</span>
             </div>
-
-            <button className="badge movieinfo-genre-badge">
-              {movie.genre}
-            </button>
-
+            <button className="badge movieinfo-genre-badge">{movie.genre}</button>
             <div className="movieinfo-meta">
-              <div>개봉: {movie.release}</div>
+              <div>개봉: {movie.release_date?.substring(0, 4)}</div>
               <div>감독: {movie.director}</div>
-              <div>배우: {movie.actors}</div>
-            </div>
-          </div>
-        </div>
-
-        {/* 하단: 별점 + 한줄평 박스 영역
-          <div className="movieinfo-rating-box">
-            <h3 className="movieinfo-subtitle">사용자 별점</h3>
-            <div className="movieinfo-score-line">
-              <span className="movieinfo-stars">★★★★☆</span>
-              <span className="movieinfo-score">{movie.rating} / 5</span>
-            </div>
-
-            <div className="movieinfo-bar-list">
-              <div className="movieinfo-bar-row">
-                <span className="bar-label">5★</span>
-                <div className="bar-track">
-                  <div className="bar-fill" style={{ width: "50%" }} />
-                </div>
-                <span className="bar-percent">50%</span>
-              </div>
-              <div className="movieinfo-bar-row">
-                <span className="bar-label">4★</span>
-                <div className="bar-track">
-                  <div className="bar-fill" style={{ width: "25%" }} />
-                </div>
-                <span className="bar-percent">25%</span>
-              </div>
-              <div className="movieinfo-bar-row">
-                <span className="bar-label">3★</span>
-                <div className="bar-track">
-                  <div className="bar-fill" style={{ width: "24%" }} />
-                </div>
-                <span className="bar-percent">24%</span>
-              </div>
-              <div className="movieinfo-bar-row">
-                <span className="bar-label">2★</span>
-                <div className="bar-track">
-                  <div className="bar-fill" style={{ width: "0%" }} />
-                </div>
-                <span className="bar-percent">0%</span>
-              </div>
-              <div className="movieinfo-bar-row">
-                <span className="bar-label">1★</span>
-                <div className="bar-track">
-                  <div className="bar-fill" style={{ width: "1%" }} />
-                </div>
-                <span className="bar-percent">1%</span>
-              </div>
-            </div>
-          </div>
- */}
-          {/* 우측: 한줄평 카드 리스트 (더미) */}
-          <div className="movieinfo-review-list">
-            <div className="movieinfo-review-card">
-              <div className="review-header">
-                <div className="review-avatar">A</div>
-                <div>
-                  <div className="review-name">
-                    <Link to="/movielog/detail2">사용자 1</Link>
-                  </div>
-                  <div className="review-tag">액션</div>
-                </div>
-
-                <div className="review-avatar">B</div>
-                <div>
-                  <div className="review-name">
-                    <Link to="/movielog/detail2">사용자 2</Link>
-                  </div>
-                  <div className="review-tag">판타지</div>
-                </div>
-              </div>
-              <p className="review-text">
-                뜨거운 안녕의 끝에서 열렬한 환영의 시작으로
-              </p>
-            </div>
-
-            <div className="movieinfo-review-card">
-              <div className="review-header">
-                <div className="review-avatar">👤</div>
-                <div>
-                  <div className="review-name">테스트 2</div>
-                  <div className="review-tag">선호 장르2</div>
-                </div>
-              </div>
-              <p className="review-text">
-                음악, 연출, 배우 연기 모두 완벽했습니다.
-              </p>
+              <div>배우: {movie.actor}</div>
+              <div>평점: ★ {movie.rating }</div>
             </div>
           </div>
         </div>
       </div>
+
+      {/* 영화 기록(한줄평/리뷰) */}
+      <div className="movieinfo-bottom">
+        <h3 className="movieinfo-subtitle">한줄평 / 리뷰</h3>
+        {reviews.length > 0 ? (
+          <div className="movieinfo-review-list">
+            {reviews.map((r) => (
+              <div className="movieinfo-review-card" key={r.num}>
+                <div className="review-header">
+                  <div className="review-avatar">{r.writer.charAt(0)}</div>
+                  <div className="review-name">{r.writer}</div>
+                  <div className="review-rate">★ {r.rate}</div>
+                </div>
+                <p className="review-text">{r.simple_review || r.review}</p>
+                <div className="review-date">
+                  {r.created_at?.substring(0, 10)}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="no-review">등록된 리뷰가 없습니다.</div>
+        )}
+      </div>
+
+    </div>
   );
 };
 

--- a/src/contents/Mypage/MyPage.css
+++ b/src/contents/Mypage/MyPage.css
@@ -377,3 +377,101 @@
 .mypage-table tbody td:nth-child(2) {
   text-align: center !important;
 }
+
+
+/* ===== 장르 통계 ===== */
+.stats-card {
+  margin-top: 24px;
+  padding: 24px;
+  border-radius: 16px;
+  border: none;
+  background: #fff;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.08);
+  transition: transform 0.3s ease;
+}
+
+.stats-card:hover {
+  transform: translateY(-3px);
+}
+
+/* 차트 영역 */
+.stats-chart {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-around;
+  height: 220px;
+  padding: 16px 8px;
+  position: relative;
+  border-left: 1px solid #dee2e6;
+  border-bottom: 1px solid #dee2e6;
+}
+
+/* 통계 막대 */
+.stats-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40px;
+  position: relative;
+}
+
+/* 막대 안쪽 색상 + 그림자 + 애니메이션 */
+.stats-bar-inner {
+  width: 100%;
+  border-radius: 8px 8px 0 0;
+  transition: all 0.6s ease;
+  position: relative;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+  background: linear-gradient(to top, #4dabf7, #1c7ed6);
+}
+
+/* 막대 위 숫자 */
+.stats-bar-inner::after {
+  content: attr(data-value);
+  position: absolute;
+  top: -24px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #495057;
+  text-align: center;
+  width: 100%;
+}
+
+/* 장르 레이블 */
+.stats-label {
+  margin-top: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  color: #333;
+  white-space: nowrap;
+}
+
+/* 장르별 막대 색상 */
+.action { background: linear-gradient(to top, #fcd098, #fc940b);}
+.comedy { background: linear-gradient(to top, #63e6be, #4ad162);}
+.romance { background: linear-gradient(to top, #d2a4f8, #9928f5);}
+.thriller { background: linear-gradient(to top, rgb(255, 234, 157), #f5e500);}
+.sf { background: linear-gradient(to top, #ff9898, #f03e3e);}
+.animation { background: linear-gradient(to top, #97d2ff, #339af0);}
+
+/* 반응형 */
+@media (max-width: 768px) {
+  .stats-bar {
+    width: 28px;
+  }
+  .stats-chart {
+    height: 160px;
+  }
+  .stats-bar-inner::after {
+    font-size: 11px;
+  }
+}
+.stats-bar-inner::after {
+  content: attr(data-value);
+}
+
+.stats-bar-inner {
+  position: relative; 
+  min-height: 8px;    
+}

--- a/src/contents/Mypage/MyPage.tsx
+++ b/src/contents/Mypage/MyPage.tsx
@@ -477,28 +477,32 @@ const MovieListSection: React.FC = () => {
 
 // ========== 작성한 게시글 ==========
 interface BoardVO {
-    num: number;
-    title: string;
-    nickname: string;
-    content: string;
-    hit: number;
-    reip: string;
-    bdate: string;
+  num: number;
+  title: string;
+  bnickname: string;
+  content: string;
+  hit: number;
+  reip: string;
+  bdate: string;
 }
+
 
 const BoardListSection: React.FC = () => {
   const [boardList, setBoardList] = React.useState<BoardVO[]>([]);
 
   React.useEffect(() => {
     axios
-      .get(`${process.env.REACT_APP_BACK_END_URL}/board/list`)
+      .get(`${process.env.REACT_APP_BACK_END_URL}/board/mylist`, {
+        withCredentials: true, 
+      })
       .then((res) => {
-        setBoardList(res.data.data);
+        setBoardList(res.data); 
       })
       .catch((err) => {
         console.error("MyPage board list load error", err);
       });
   }, []);
+
 
   return(
   <>
@@ -515,7 +519,14 @@ const BoardListSection: React.FC = () => {
       </thead>
 
       <tbody>
-          {boardList.map((board, idx) => (
+        {boardList.length === 0 ? (
+          <tr>
+            <td colSpan={3} style={{ textAlign: "center", padding: "20px" }}>
+              작성한 게시글이 없습니다.
+            </td>
+          </tr>
+        ) : (
+          boardList.map((board, idx) => (
             <tr key={board.num}>
               <td>{boardList.length - idx}</td>
               <td>
@@ -525,8 +536,11 @@ const BoardListSection: React.FC = () => {
               </td>
               <td>{board.bdate}</td>
             </tr>
-          ))}
-        </tbody>
+          ))
+        )}
+      </tbody>
+
+
     </table>
   </>
 );

--- a/src/contents/Mypage/MyPage.tsx
+++ b/src/contents/Mypage/MyPage.tsx
@@ -565,8 +565,6 @@ const GalleryListSection: React.FC = () => (
             </div>
           </td>
         </tr>
-
-
       </tbody>
     </table>
   </>
@@ -632,52 +630,62 @@ const InquirySection: React.FC = () => (
 );
 
 // ========== 장르 통계 ==========
-const StatsSection: React.FC = () => (
-  <>
-    <h2 className="mypage-title">장르 통계</h2>
+type GenreStats = {
+  [key: string]: number;
+};
 
-    <div className="stats-card">
-      <div className="stats-chart">
-        <div className="stats-bar">
-          <div
-            className="stats-bar-inner bg-primary"
-            style={{ height: "55px" }}
-          />
-          <span className="stats-label">액션</span>
-        </div>
-        <div className="stats-bar">
-          <div
-            className="stats-bar-inner bg-success"
-            style={{ height: "30px" }}
-          />
-          <span className="stats-label">코미디</span>
-        </div>
-        <div className="stats-bar">
-          <div className="stats-bar-inner bg-info" style={{ height: "75px" }} />
-          <span className="stats-label">로맨스</span>
-        </div>
-        <div className="stats-bar">
-          <div
-            className="stats-bar-inner bg-warning"
-            style={{ height: "45px" }}
-          />
-          <span className="stats-label">공포/스릴러</span>
-        </div>
-        <div className="stats-bar">
-          <div
-            className="stats-bar-inner bg-danger"
-            style={{ height: "90px" }}
-          />
-          <span className="stats-label">SF/판타지</span>
-        </div>
-        <div className="stats-bar">
-          <div
-            className="stats-bar-inner bg-secondary"
-            style={{ height: "50px" }}
-          />
-          <span className="stats-label">애니메이션</span>
+const genreClassMap: { [key: string]: string } = {
+  "액션": "action",
+  "코미디": "comedy",
+  "로맨스": "romance",
+  "공포/스릴러": "thriller",
+  "SF/판타지": "sf",
+  "애니메이션": "animation",
+};
+
+const StatsSection: React.FC = () => {
+  const [genreStats, setGenreStats] = useState<GenreStats>({});
+
+  useEffect(() => {
+    axios
+      .get("http://192.168.0.40/movie/movie/genre-stats", {
+        withCredentials: true,
+      })
+      .then((res) => {
+        setGenreStats(res.data);
+      })
+      .catch((err) => {
+        console.error("장르 통계 조회 실패", err);
+      });
+  }, []);
+
+  // 최대값 기준으로 막대 높이 계산
+  const values = Object.values(genreStats);
+  const maxValue = values.length > 0 ? Math.max(...values) : 0;
+
+  const getHeight = (value: number) => {
+    if (maxValue === 0) return 0;
+    // 최소 높이 8px 보장 (값이 작아도 보이게)
+    return Math.max((value / maxValue) * 180, 8);
+  };
+
+  return (
+    <>
+      <h2 className="mypage-title">영화 장르 통계</h2>
+      <div className="stats-card">
+        <div className="stats-chart">
+          {Object.entries(genreStats).map(([genre, value]) => (
+            <div className="stats-bar" key={genre}>
+              <div
+                className={`stats-bar-inner ${genreClassMap[genre] || ""}`}
+                style={{ height: `${getHeight(value)}px` }}
+                data-value={value}
+              />
+              <span className="stats-label">{genre}</span>
+            </div>
+          ))}
         </div>
       </div>
-    </div>
-  </>
-);
+    </>
+  );
+};

--- a/src/contents/Search/ActorSearch.tsx
+++ b/src/contents/Search/ActorSearch.tsx
@@ -16,13 +16,11 @@ interface MovieVO {
 const ActorSearch: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const actorRef = useRef<HTMLDivElement>(null);
 
   const isGenre = location.pathname === "/Search";
   const isDirector = location.pathname === "/Search/Director";
-  const isActor =
-    location.pathname === "/Search/Actor" || location.pathname === "/actor";
-
-  const actorRef = useRef<HTMLDivElement>(null);
+  const isActor = location.pathname === "/Search/Actor" || location.pathname === "/actor";
 
   const [movies, setMovies] = useState<MovieVO[]>([]);
   const [originMovies, setOriginMovies] = useState<MovieVO[]>([]);
@@ -38,13 +36,12 @@ const ActorSearch: React.FC = () => {
   const pagePerBlock = 5;
   const cardsPerPage = 9;
 
+  // 영화 목록 불러오기
   useEffect(() => {
     const fetchMovies = async () => {
       setLoading(true);
       try {
-        const res = await axios.get(
-          `${process.env.REACT_APP_BACK_END_URL}/movie/movielist`
-        );
+        const res = await axios.get(`${process.env.REACT_APP_BACK_END_URL}/movie/movielist`);
         const movieList: MovieVO[] = res.data.movie || [];
         setMovies(movieList);
         setOriginMovies(movieList);
@@ -103,10 +100,7 @@ const ActorSearch: React.FC = () => {
 
   // 현재 페이지 영화
   const startIndex = (currentPage - 1) * cardsPerPage;
-  const currentMovies = filteredMovies.slice(
-    startIndex,
-    startIndex + cardsPerPage
-  );
+  const currentMovies = filteredMovies.slice(startIndex, startIndex + cardsPerPage);
 
   // 페이지네이션 블록
   const block = Math.ceil(currentPage / pagePerBlock);
@@ -181,9 +175,7 @@ const ActorSearch: React.FC = () => {
           {actors.map((actor) => (
             <button
               key={actor}
-              className={`genre-btn ${
-                selectedActor === actor ? "active" : ""
-              }`}
+              className={`genre-btn ${selectedActor === actor ? "active" : ""}`}
               onClick={() => {
                 setSelectedActor(actor);
                 setCurrentPage(1);
@@ -216,6 +208,7 @@ const ActorSearch: React.FC = () => {
                     src={movie.poster}
                     className="card-img-top movie-poster"
                     alt={movie.title}
+                    onClick={() => navigate(`/MovieInfo/${movie.num}`)} 
                     onError={(e) => {
                       e.currentTarget.src = "/images/no-poster.png";
                     }}
@@ -253,31 +246,22 @@ const ActorSearch: React.FC = () => {
               </li>
             )}
 
-            {Array.from(
-              { length: endPage - startPage + 1 },
-              (_, i) => startPage + i
-            ).map((page) => (
-              <li
-                key={page}
-                className={`page-item ${
-                  page === currentPage ? "active" : ""
-                }`}
-              >
-                <button
-                  className="page-link"
-                  onClick={() => setCurrentPage(page)}
+            {Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map(
+              (page) => (
+                <li
+                  key={page}
+                  className={`page-item ${page === currentPage ? "active" : ""}`}
                 >
-                  {page}
-                </button>
-              </li>
-            ))}
+                  <button className="page-link" onClick={() => setCurrentPage(page)}>
+                    {page}
+                  </button>
+                </li>
+              )
+            )}
 
             {endPage < totalPages && (
               <li className="page-item">
-                <button
-                  className="page-link"
-                  onClick={() => setCurrentPage(endPage + 1)}
-                >
+                <button className="page-link" onClick={() => setCurrentPage(endPage + 1)}>
                   다음
                 </button>
               </li>

--- a/src/contents/Search/DirectorSearch.tsx
+++ b/src/contents/Search/DirectorSearch.tsx
@@ -178,6 +178,7 @@ const DirectorSearch: React.FC = () => {
                     src={movie.poster}
                     className="card-img-top movie-poster"
                     alt={movie.title}
+                    onClick={() => navigate(`/MovieInfo/${movie.num}`)} 
                     onError={(e) => {
                       e.currentTarget.src = "/images/no-poster.png";
                     }}

--- a/src/contents/Search/GenreSearch.tsx
+++ b/src/contents/Search/GenreSearch.tsx
@@ -192,6 +192,7 @@ const GenreSearch: React.FC = () => {
                     src={movie.poster}
                     className="card-img-top movie-poster"
                     alt={movie.title}
+                    onClick={() => navigate(`/MovieInfo/${movie.num}`)}
                     onError={(e) => {
                       e.currentTarget.src = "/images/no-poster.png";
                     }}

--- a/src/router/AppRoutes.tsx
+++ b/src/router/AppRoutes.tsx
@@ -50,7 +50,7 @@ const AppRoutes: React.FC = () => {
     { path: "/Search/Director", element: <DirectorSearch /> },
     { path: "/Search/Actor", element: <ActorSearch /> },
 
-    { path: "/MovieInfo", element: <MovieInfo /> },
+    { path: "/MovieInfo/:movieId", element: <MovieInfo /> },
 
 
     { path: '/board/list', element: <BoardList/>},


### PR DESCRIPTION
**마이페이지 장르 통계 연동**
<img width="1654" height="721" alt="통계" src="https://github.com/user-attachments/assets/bff39e3b-46c6-4fa4-abc1-0f7c6d03458b" />

<br/>

**마이페이지 본인 작성 게시글만 보이도록 수정**

- 유저: kim
<img width="1067" height="560" alt="마이페이지 작성 한 게시글이 없을때" src="https://github.com/user-attachments/assets/59e31eaa-84bc-489f-b995-8523c5e57596" />
<img width="943" height="462" alt="게시판1" src="https://github.com/user-attachments/assets/a75785ce-0baa-4088-aa75-1a8497b9b08c" />
<img width="1055" height="379" alt="게시판2" src="https://github.com/user-attachments/assets/421e3c01-9791-4334-89c2-fedf2b19bcff" />

<br/>

<br/>

**MovieInfo 페이지 구현**

- 영화 검색에서 [아바타] 영화 클릭 시 해당 페이지로 이동
- [아바타] 에 해당하는 영화 기록 게시글만 출력됨
<img width="1506" height="852" alt="image" src="https://github.com/user-attachments/assets/c1d75abf-9214-44c4-a425-ba932801daf9" />


<br/>

<br/>

**다이어리 연동 오류 수정**
<img width="1495" height="832" alt="image" src="https://github.com/user-attachments/assets/ab12cbd1-9535-4bad-a350-557a00245159" />
